### PR TITLE
Detect cycles and abort

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var {basename} = require('path')
 var streamEqual = require('stream-equal')
 var debug = require('debug')('diff-file-tree')
 var {wrapFS, join, CycleError} = require('./util')
@@ -138,7 +139,7 @@ exports.diff = async function diff (left, right, opts) {
 
   function checkForCycle (st, path) {
     if (!st.ino) return // not all "filesystem" implementations we use have inodes (eg Dat)
-    var id = st.dev + '-' + st.ino
+    var id = `${st.dev}-${st.ino}-${basename(path)}` // include basename because windows apparently gives dup inodes sometimes
     if (seen.has(id)) {
       throw new CycleError(path)
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Compare two file-trees, get a list of changes, then apply left or right",
   "main": "index.js",
   "scripts": {
-    "test": "standard && tape test/*.test.js"
+    "test": "standard --fix && tape test/*.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/cycles.test.js
+++ b/test/cycles.test.js
@@ -1,0 +1,29 @@
+const test = require('tape')
+const {mock, mockCyclical} = require('./util')
+const dft = require('../index')
+
+test('diff with cycles (left)', async t => {
+  try {
+    var left = mockCyclical()
+    var right = mock(['/subdir/', '/subdir/foo.txt', '/bar.txt'])
+    var res = await dft.diff({fs: left}, {fs: right})
+    console.log('Got', res)
+    t.fail('Should have thrown')
+  } catch (err) {
+    t.is(err.name, 'CycleError')
+  }
+  t.end()
+})
+
+test('diff with cycles (right)', async t => {
+  try {
+    var left = mock(['/subdir/', '/subdir/foo.txt', '/bar.txt'])
+    var right = mockCyclical()
+    var res = await dft.diff({fs: left}, {fs: right})
+    console.log('Got', res)
+    t.fail('Should have thrown')
+  } catch (err) {
+    t.is(err.name, 'CycleError')
+  }
+  t.end()
+})

--- a/test/util.js
+++ b/test/util.js
@@ -18,6 +18,14 @@ module.exports.mock = function mock (desc) {
   return sfs
 }
 
+module.exports.mockCyclical = function mockCyclical () {
+  var sfs = new ScopedFS(tempy.directory())
+  fs.mkdirSync(path.join(sfs.base, 'subdir'))
+  fs.writeFileSync(path.join(sfs.base, 'subdir', 'foo.txt'), 'more content', 'utf8')
+  fs.symlinkSync(sfs.base, path.join(sfs.base, 'subdir', 'symlink'))
+  return sfs
+}
+
 module.exports.sortDiffs = function sortDiffs (diffs) {
   diffs = diffs.slice() // clone the array
   diffs.sort(function (a, b) {

--- a/util.js
+++ b/util.js
@@ -61,3 +61,12 @@ exports.wrapFS = function (desc) {
 }
 
 async function noop () {}
+
+exports.CycleError = class CycleError extends Error {
+  constructor (path) {
+    var msg = `Aborting file-tree comparison, a symlink or hardlink loop was detected at ${path}`
+    super(msg)
+    this.name = 'CycleError'
+    this.message = msg
+  }
+}


### PR DESCRIPTION
One of our users had a symlink cycle in a folder they were syncing with Beaker and it was spinning out of control (https://github.com/beakerbrowser/beaker/issues/1014). This PR watches for cycles and aborts the diff when found.