### PR TITLE
Adding op context to the filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Options include:
 
 ```js
 {
-  filter: null // optional function to ignore files (function (path) => bool)
+  filter: null // optional function to ignore files (function (path, op) => bool)
   shallow: false // dont recurse into folders that need to be added or removed
   sizeLimit: {
     maxSize: undefined // max number of bytes before comparison aborts

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ exports.diff = async function diff (left, right, opts) {
 
   async function diff (path) {
     debug('diff', path)
-    if (opts.filter && opts.filter(path)) {
+    if (opts.filter && opts.filter(path, "diff")) {
       return
     }
     // stat the entry
@@ -118,7 +118,7 @@ exports.diff = async function diff (left, right, opts) {
 
   async function addRecursive (path, isFirstRecursion = false) {
     debug('addRecursive', path)
-    if (opts.filter && opts.filter(path)) {
+    if (opts.filter && opts.filter(path, "add")) {
       return
     }
     // find everything at and below the current path in staging
@@ -142,7 +142,7 @@ exports.diff = async function diff (left, right, opts) {
 
   async function delRecursive (path, isFirstRecursion = false) {
     debug('delRecursive', path)
-    if (opts.filter && opts.filter(path)) {
+    if (opts.filter && opts.filter(path, "del")) {
       return
     }
     // find everything at and below the current path in the archive


### PR DESCRIPTION
The filter context allows diff to ignore the changes based on operation also (such as, ignore all "del" ops irrespective of filename). This eliminates the need for post-filtering of diff changes.

Needed for some other package of mine that is using this package.

This change is backwards compatible, which means existing code should run fine.


